### PR TITLE
Update to 1.2.2

### DIFF
--- a/ACRCloudSdkCore.Example/Program.cs
+++ b/ACRCloudSdkCore.Example/Program.cs
@@ -9,6 +9,7 @@ namespace ACRCloudSdkCore.Example
         {
             ACRCloudOptions options = new ACRCloudOptions("**Your host**", "**Your access key**", "**Your access secret**");
             ACRCloudRecognizer recognizer = new ACRCloudRecognizer(options);
+            // Using this reload will fail when the path contains kana
             ACRCloudRecognizeResult result = await recognizer.RecognizeByFileAsync(@"**filePath**");
             if (result == null)
             {

--- a/ACRCloudSdkCore/ACRCloudExtractTools.NativeMethods.cs
+++ b/ACRCloudSdkCore/ACRCloudExtractTools.NativeMethods.cs
@@ -14,7 +14,7 @@ namespace ACRCloudSdkCore
             [DllImport(ExtractToolName, EntryPoint = "create_fingerprint")]
             public static extern int CreateFingerprint(ref byte pcm_buffer, int pcm_buffer_len, [MarshalAs(UnmanagedType.I1)] bool is_db_fingerprint, int filter_energy_min, int silence_energy_threshold, float silence_rate_threshold, out byte* fps_buffer);
 
-            [DllImport(ExtractToolName, EntryPoint = "create_fingerprint_by_file")]
+            [DllImport(ExtractToolName, EntryPoint = "create_fingerprint_by_file", CharSet = CharSet.Ansi)]
             public static extern int CreateFingerprint(string file_path, int start_time_seconds, int audio_len_seconds, [MarshalAs(UnmanagedType.I1)] bool is_db_fingerprint, int filter_energy_min, int silence_energy_threshold, float silence_rate_threshold, out byte* fps_buffer);
 
             [DllImport(ExtractToolName, EntryPoint = "create_fingerprint_by_filebuffer")]

--- a/ACRCloudSdkCore/ACRCloudRecognizer.Recognize.cs
+++ b/ACRCloudSdkCore/ACRCloudRecognizer.Recognize.cs
@@ -37,7 +37,7 @@ namespace ACRCloudSdkCore
                 }
             }
             FormUrlEncodedContent content = new FormUrlEncodedContent(getContents().Concat(GetCommonContents()));
-            Task<HttpResponseMessage> response = Client.PostAsync($"http://{Options.Host}/v2/identify", content, token);
+            Task<HttpResponseMessage> response = Client.PostAsync($"http://{Options.Host}/v1/identify", content, token);
             return CreateResultAsync(response);
         }
     }

--- a/ACRCloudSdkCore/ACRCloudRecognizer.RecognizeByFile.cs
+++ b/ACRCloudSdkCore/ACRCloudRecognizer.RecognizeByFile.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -37,6 +38,9 @@ namespace ACRCloudSdkCore
         /// <summary>
         /// Recognizes the audio file as an asynchronous operation.
         /// </summary>
+        /// <remarks>
+        /// When the <paramref name="filePath"/> contains kana, it will fail with <see cref="InvalidDataException"/>.
+        /// </remarks>
         /// <exception cref="HttpRequestException"/>
         /// <param name="type">The audio type.</param>
         /// <param name="token">A <see cref="CancellationToken"/> which may be used to cancel the recognize operation.</param>
@@ -66,7 +70,7 @@ namespace ACRCloudSdkCore
                 }
             }
             FormUrlEncodedContent content = new FormUrlEncodedContent(getContents().Concat(GetCommonContents()));
-            Task<HttpResponseMessage> response = Client.PostAsync($"http://{Options.Host}/v2/identify", content, token);
+            Task<HttpResponseMessage> response = Client.PostAsync($"http://{Options.Host}/v1/identify", content, token);
             return CreateResultAsync(response);
         }
     }

--- a/ACRCloudSdkCore/ACRCloudRecognizer.RecognizeByFileBuffer.cs
+++ b/ACRCloudSdkCore/ACRCloudRecognizer.RecognizeByFileBuffer.cs
@@ -103,7 +103,7 @@ namespace ACRCloudSdkCore
                 }
             }
             FormUrlEncodedContent content = new FormUrlEncodedContent(getContents().Concat(GetCommonContents()));
-            Task<HttpResponseMessage> response = Client.PostAsync($"http://{Options.Host}/v2/identify", content, token);
+            Task<HttpResponseMessage> response = Client.PostAsync($"http://{Options.Host}/v1/identify", content, token);
             return CreateResultAsync(response);
         }
     }

--- a/ACRCloudSdkCore/ACRCloudRecognizer.cs
+++ b/ACRCloudSdkCore/ACRCloudRecognizer.cs
@@ -61,6 +61,12 @@ namespace ACRCloudSdkCore
         /// <exception cref="UnknownResponseException"/>
         private async Task<ACRCloudRecognizeResult?> CreateResultAsync(Task<HttpResponseMessage> response) // Suppress all CS8602/CS8604 in JToken[string] / JToken.ToObject<T>
         {
+            HttpResponseMessage resp = await response;
+            if (resp.Content.Headers.ContentType?.MediaType != "application/json")
+            {
+                string content = await response.GetStringAsync();
+                throw new UnknownResponseException(content);
+            }
 #if NETSTANDARD2_0 || NETFRAMEWORK
             JObject root = (JObject)await response.GetJsonAsync();
             JToken status = root["status"]!;

--- a/ACRCloudSdkCore/ACRCloudSdkCore.csproj
+++ b/ACRCloudSdkCore/ACRCloudSdkCore.csproj
@@ -8,9 +8,10 @@
     <OutputType>Library</OutputType>
     <Nullable>enable</Nullable>
     <NoWin32Manifest>true</NoWin32Manifest>
-    <Version>1.2.1.0</Version>
-    <AssemblyVersion>1.2.1.0</AssemblyVersion>
-    <FileVersion>1.2.1.0</FileVersion>
+    <Version>1.2.2.0</Version>
+    <AssemblyVersion>1.2.2.0</AssemblyVersion>
+    <FileVersion>1.2.2.0</FileVersion>
+    <PackageVersion>1.2.2-preview.1</PackageVersion>
     <Authors>Executor</Authors>
     <Company>Executor</Company>
     <Copyright>Copyright © Executor 2022</Copyright>

--- a/ACRCloudSdkCore/ACRCloudSdkCore.csproj
+++ b/ACRCloudSdkCore/ACRCloudSdkCore.csproj
@@ -11,7 +11,7 @@
     <Version>1.2.2.0</Version>
     <AssemblyVersion>1.2.2.0</AssemblyVersion>
     <FileVersion>1.2.2.0</FileVersion>
-    <PackageVersion>1.2.2-preview.1</PackageVersion>
+    <PackageVersion>1.2.2.0</PackageVersion>
     <Authors>Executor</Authors>
     <Company>Executor</Company>
     <Copyright>Copyright © Executor 2022</Copyright>


### PR DESCRIPTION
Throws `HttpRequestException` when response status code does not indicate success.
Fix v2 api obsoleted issue.
Add a warning for `ACRCloudRecognizer.RecognizeByFileAsync`.

close #9 